### PR TITLE
Add handling to report missing permissions when using kick/ban

### DIFF
--- a/commands/ban.py
+++ b/commands/ban.py
@@ -1,3 +1,4 @@
+from discord import Forbidden
 from discord.ext import commands
 from util.pyutil import buildMultiMatchString, splitArgs
 from util.discordutil import resolveMember, modActionLogEmbed
@@ -45,7 +46,13 @@ class Ban(commands.Cog, name='Ban'):
 				await ctx.guild.ban(mem, reason=reason)
 				if self.modLogChannelID is not None:
 					await ctx.guild.get_channel(self.modLogChannelID).send(embed=modActionLogEmbed('Banned',mem,reason,ctx.author))
-			except Exception:
+			except Forbidden as e:
+				errMessage = str(e)
+				if 'error code: 50013' in errMessage:
+					await ctx.send("I don't have permission to do that!")
+			except Exception as e:
+				print('encountered an unknown error in kick command:')
+				print(repr(e))
 				await ctx.send('An unknown error occured. Please try again later')
 
 def setup(bot):

--- a/commands/kick.py
+++ b/commands/kick.py
@@ -1,3 +1,4 @@
+from discord import Forbidden
 from discord.ext import commands
 from util.pyutil import buildMultiMatchString, splitArgs
 from util.discordutil import resolveMember, modActionLogEmbed
@@ -38,6 +39,7 @@ class Kick(commands.Cog, name='Kick'):
 				try:
 					if args[0][indexReason] is not None:
 						reason = args[0][indexReason]
+				
 				except Exception:
 					await ctx.send('An error occurred while attempting to parse arguments')
 					return
@@ -45,7 +47,13 @@ class Kick(commands.Cog, name='Kick'):
 				await ctx.guild.kick(mem, reason=reason)
 				if self.modLogChannelID is not None:
 					await ctx.guild.get_channel(self.modLogChannelID).send(embed=modActionLogEmbed('Kicked',mem,reason,ctx.author))
-			except Exception:
+			except Forbidden as e:
+				errMessage = str(e)
+				if 'error code: 50013' in errMessage:
+					await ctx.send("I don't have permission to do that!")
+			except Exception as e:
+				print('encountered an unknown error in kick command:')
+				print(repr(e))
 				await ctx.send('An unknown error occured. Please try again later')
 
 def setup(bot):


### PR DESCRIPTION
Bot will now report that it doesn't have sufficient permissions to preform a kick/ban when requested, instead of a cryptic "unknown error". Additionally, any future "unknown error" that occur here will log the error that causes it, making future additions of these more informative replies easier.