### PR TITLE
fix: correct occured to occurred typos in error messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -26,7 +26,7 @@ async def on_ready():
 async def on_command_error(ctx, error):
 	if isinstance(error,commands.errors.CommandNotFound):
 		return
-	await ctx.send("An error occured!\n```{}```".format(error))
+	await ctx.send("An error occurred!\n```{}```".format(error))
 '''
 		
 for cog in os.listdir(f".{os.path.sep}commands"):#path

--- a/commands/ban.py
+++ b/commands/ban.py
@@ -46,7 +46,7 @@ class Ban(commands.Cog, name='Ban'):
 				if self.modLogChannelID is not None:
 					await ctx.guild.get_channel(self.modLogChannelID).send(embed=modActionLogEmbed('Banned',mem,reason,ctx.author))
 			except Exception:
-				await ctx.send('An unknown error occured. Please try again later')
+				await ctx.send('An unknown error occurred. Please try again later')
 
 def setup(bot):
 	bot.add_cog(Ban(bot))

--- a/commands/kick.py
+++ b/commands/kick.py
@@ -46,7 +46,7 @@ class Kick(commands.Cog, name='Kick'):
 				if self.modLogChannelID is not None:
 					await ctx.guild.get_channel(self.modLogChannelID).send(embed=modActionLogEmbed('Kicked',mem,reason,ctx.author))
 			except Exception:
-				await ctx.send('An unknown error occured. Please try again later')
+				await ctx.send('An unknown error occurred. Please try again later')
 
 def setup(bot):
 	bot.add_cog(Kick(bot))


### PR DESCRIPTION
Fix 3 instances of 'occured' → 'occurred' in user-facing Discord bot error messages. Changes in bot.py and commands/kick.py and commands/ban.py.